### PR TITLE
Add MAEC Releases Archive page

### DIFF
--- a/releases/archive/index.md
+++ b/releases/archive/index.md
@@ -1,0 +1,16 @@
+---
+layout: flat
+title: MAEC Releases Archive
+---
+
+**Note:** All previous releases linked to below are hosted on the [MAEC Legacy Site](https://maec.mitre.org), and will redirect there.
+
+|Release|Release Date|
+|-------|------------|
+|[MAEC 4.0.1](https://maec.mitre.org/language/version4.0.1/)|February 11, 2014|
+|[MAEC 4.0](https://maec.mitre.org/language/version4.0/)|September 27, 2013|
+|[MAEC 3.0](https://maec.mitre.org/language/version3.0/)|April 30, 2013|
+|[MAEC 2.1](https://maec.mitre.org/language/version2.1/)|December 5, 2012|
+|[MAEC 2.0](https://maec.mitre.org/language/version2.0/)|April 27, 2012|
+|[MAEC 1.1](https://maec.mitre.org/language/version1.1/)|January 26, 2012|
+|[MAEC 1.01](https://maec.mitre.org/language/version1.01/)|January 14, 2011|


### PR DESCRIPTION
Added new page.  All links for previous releases go back to the MAEC legacy website.