### PR TITLE
Updated Working Calls page

### DIFF
--- a/working-call/index.md
+++ b/working-call/index.md
@@ -3,22 +3,22 @@ layout: flat
 title: MAEC Working Calls
 ---
 
-Beginning Wednesday, September 28, 2016, the MAEC Team will be hosting the first of a series of 1-hour, bi-weekly, working session calls for [MAEC Version 5.0](http://maecproject.github.io/documentation/roadmap/). 
+The MAEC Team is hosting a series of 1-hour, bi-weekly, working session calls for [MAEC Version 5.0](http://maecproject.github.io/documentation/roadmap/). 
 
 Each bi-weekly call will focus on a particular topic. However, we very much welcome suggestions from our community, so please [let us know](maec@mitre.org) what you’d like to discuss for any meeting. Anything MAEC-related is relevant! 
 
 ## Next Bi-Weekly Working Call
 
-September 28, 2016
+October 26, 2016
 
 ### Agenda
 
-The [Malware Family Object](https://docs.google.com/document/d/1cnjjZAPHITFjo_8xGVBo1mX9Qvo7pN-YJ4pRZwdsuL0/edit#heading=h.c3b7rqfk03ax). 
+TBA
  
 ### Dial-in Info
 
-**Online meeting:**  [https://meet.mitre.org/ikirillov/7F073TTD](https://meet.mitre.org/ikirillov/7F073TTD)          
-**Conference ID:**   9326128          
+**Online meeting:**  TBA         
+**Conference ID:**   TBA        
 
 **Join by Phone:** 
 +1 (781) 271-2020 
@@ -26,6 +26,7 @@ The [Malware Family Object](https://docs.google.com/document/d/1cnjjZAPHITFjo_8x
  
 ## Previous Working Calls
 
+* September 28, 2016 - Topic: "The Malware Family Object"/[Details](http://stixproject.tumblr.com/post/150968749062/maec-50-working-call-on-september-28-to-focus-on)
 * September 14, 2016 - [Details](http://stixproject.tumblr.com/post/150092860697/call-details-final-agenda-for-2nd-maec-50)/[Materials](http://making-security-measurable.1364806.n2.nabble.com/Re-MAEC-MAEC-5-0-Working-Session-td7589436.html#a7589449)
 * July 20, 2016 - [Details](http://stixproject.tumblr.com/post/147458851807/call-details-final-agenda-for-maec-50-working)
 


### PR DESCRIPTION
Prepped the page for the next call scheduled for 10/26/16. Moved the info from the 9/28/16 call to under "Previous Working Calls" subsection of page.