### PR TITLE
Updated main site nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -72,6 +72,7 @@
             <li role="presentation"><a href="/documentation/suggested_practices">Suggested Practices</a></li>
 			<li role="presentation"><a href="/documentation/data_model_overview">Data Model Overview</a></li>
 			<li role="presentation"><a href="/documentation/common_features">Common Features</a></li>
+		  	<li role="presentation"><a href="/documentation/versioning_policy">Versioning Policy</a></li>
 			<li role="presentation"><a href="/documentation/utils">Utilities</a></li>
 			<li role="presentation"><a href="/documentation/characterize_malware/Characterizing_Malware_MAEC_and_STIX_v1.0.pdf">Characterizing Malware</a></li>
 			<li role="presentation"><a href="/documentation/faqs">FAQs</a></li>


### PR DESCRIPTION
Added a link to the Versioning Policy page in the Documentation drop-down menu in the main site nav.