### PR TITLE
Updated MalwareSubjectType page

### DIFF
--- a/data-model/4.1/maecPackage/MalwareSubjectType/index.html
+++ b/data-model/4.1/maecPackage/MalwareSubjectType/index.html
@@ -73,7 +73,7 @@ this_version: 4.1
       </td>
       <td>
         
-          <p>The Malware_Instance_Object_Attributes field characterizes the attributes of the malware instance object (most commonly a file) that is encompassed in the Malware_Subject, via its corresponding CybOX Object. For example, a file would be represented via a CybOX File field of type FileObj:FileObjectType and may have a file name, MD5 hash, etc.</p>
+          <p>The Malware_Instance_Object_Attributes field characterizes the attributes of the malware instance object (most commonly a file) that is encompassed in the Malware_Subject, via its corresponding <a href="https://cyboxproject.github.io/">Cyber Observable eXpression (CybOX™)</a> Object. For example, a file would be represented via a CybOX File field of type FileObj:FileObjectType and may have a file name, MD5 hash, etc.</p>
         
       </td>
     </tr>
@@ -87,7 +87,7 @@ this_version: 4.1
       </td>
       <td>
         
-          <p>The Label field specifies a single commonly accepted label to describe the Malware Subject, e.g. "worm". The default vocabulary for this field is the <a href='/data-model/4.1/maecVocabs/MalwareLabelVocab-1.0'>MalwareLabelVocab-1.0</a> from the MAEC Default Vocabularies schema. More than one label may be specified through the use of multiple instances of this field.</p>
+          <p>The Label field specifies a single commonly accepted label to describe the Malware Subject, e.g., "worm". The default vocabulary for this field is the <a href='/data-model/4.1/maecVocabs/MalwareLabelVocab-1.0'>MalwareLabelVocab-1.0</a> from the MAEC Default Vocabularies schema. More than one label may be specified through the use of multiple instances of this field.</p>
         
       </td>
     </tr>
@@ -199,7 +199,7 @@ this_version: 4.1
       </td>
       <td>
         
-          <p>The Compatible_Platform field specifies a single platform that the Malware Subject is compatible with (i.e. can execute on). It uses the <a href='/data-model/4.1/cyboxCommon/PlatformSpecificationType'>PlatformSpecificationType</a> from the imported CybOX Common schema. More than one compatible platform can be specified by using multiple occurrences of this field.</p>
+          <p>The Compatible_Platform field specifies a single platform that the Malware Subject is compatible with (i.e., can execute on). It uses the <a href='/data-model/4.1/cyboxCommon/PlatformSpecificationType'>PlatformSpecificationType</a> from the imported CybOX Common schema. More than one compatible platform can be specified by using multiple occurrences of this field.</p>
         
       </td>
     </tr>


### PR DESCRIPTION
spelled-out acronym and added two missing punctuation marks