### PR TITLE
Updated Working Calls page

### DIFF
--- a/working-call/index.md
+++ b/working-call/index.md
@@ -5,17 +5,16 @@ title: MAEC Working Calls
 
 The MAEC Team is hosting a series of 1-hour, bi-weekly, working session calls for [MAEC Version 5.0](http://maecproject.github.io/documentation/roadmap/). 
 
-Each bi-weekly call will focus on a particular topic. However, we very much welcome suggestions from our community, so please [let us know](maec@mitre.org) what you’d like to discuss for any meeting. Anything MAEC-related is relevant! 
+Each bi-weekly call will focus on one or so specific topics. However, we very much welcome suggestions from our community, so please [let us know](maec@mitre.org) what you’d like to discuss for any meeting. Anything MAEC-related is relevant! 
 
 ## Next Bi-Weekly Working Call
 
-November 9, 2016          
+November 23, 2016          
 11:00 a.m. – 12:00 p.m. EST
 
 ### Agenda
 
-* [Malware Action](https://docs.google.com/document/d/1cnjjZAPHITFjo_8xGVBo1mX9Qvo7pN-YJ4pRZwdsuL0/edit#heading=h.yn04yetlim3i)          
-* [Behavior](https://docs.google.com/document/d/1cnjjZAPHITFjo_8xGVBo1mX9Qvo7pN-YJ4pRZwdsuL0/edit#heading=h.36ycvus6kelz)          
+TBA
  
 ### Dial-in Info
 
@@ -29,6 +28,7 @@ November 9, 2016
  
 ## Previous Working Calls
 
+* November 9, 2016 - Topics: "Malware Action" & "Behavior"/[Details](http://stixproject.tumblr.com/post/152866156897/maec-50-working-call-on-november-9-to-focus-on)
 * October 26, 2016 - Topic: "Malware Family Instance"/[Details](http://stixproject.tumblr.com/post/152250179367/maec-50-working-call-on-october-26-to-focus-on)/[Materials](http://making-security-measurable.1364806.n2.nabble.com/MAEC-MAEC-5-0-JSON-Examples-tc7589463.html)
 * September 28, 2016 - Topic: "Malware Family Object"/[Details](http://stixproject.tumblr.com/post/150968749062/maec-50-working-call-on-september-28-to-focus-on)
 * September 14, 2016 - [Details](http://stixproject.tumblr.com/post/150092860697/call-details-final-agenda-for-2nd-maec-50)/[Materials](http://making-security-measurable.1364806.n2.nabble.com/Re-MAEC-MAEC-5-0-Working-Session-td7589436.html#a7589449)


### PR DESCRIPTION
Updated page for the next call scheduled for 11/23/16. Also, updated the "Previous Working Calls" section with info from the 11/9 call.