### PR TITLE
Updated 5.0 Roadmap page

### DIFF
--- a/documentation/roadmap/index.md
+++ b/documentation/roadmap/index.md
@@ -5,7 +5,7 @@ title: MAEC 5.0 Roadmap
 
 The roadmap for Version 5.0 of the MAEC Language is below. We welcome any feedback regarding the release, either at the GitHub issue tracker link below, or directly to <a href="mailto:maec@mitre.org">maec@mitre.org</a> or the <a href="http://maecproject.github.io/community/#discussion-lists--archives">MAEC Community Email Discussion List</a>. 
 
-Also, we are currently actively hosting "<a href="/working-call">MAEC 5.0 Working Session Calls</a>" focusing on this next version of the MAEC Language. Please visit the <a href="/working-call">working call</a> page in the <a href="/community">MAEC Community</a> section for details on how you can participate.
+We also recently hosted a series of "<a href="/working-call">MAEC 5.0 Working Session Calls</a>" focusing on this next version of the MAEC Language. Please visit the <a href="/working-call">working call</a> page in the <a href="/community">MAEC Community</a> section to review an <a href="/working-call/#maec-50-working-calls-archive">archive</a> of those calls.
 
 <div class="row">
   <div class="col-md-6">
@@ -22,9 +22,6 @@ Also, we are currently actively hosting "<a href="/working-call">MAEC 5.0 Workin
 			</ul>
 		  </li>
 		  <li>New output format: JSON
-		    <ul>
-			  <li>Incorporation of <a href="http://cyboxproject.github.io/">Cyber Observable eXpression (CybOX™) 3.0</a></li>
-                        </ul>
 		  </li>
 		  <li>Major refactoring of many structures for simplicity and ease-of-use</li>
 		  <li>Addition of structures for capturing function fingerprints</li>


### PR DESCRIPTION
Updated the page to move the Working Calls info to archive status. Also, removed the bullet about incorporating CybOX 3.0.