### PR TITLE
Update multisitenav.html

### DIFF
--- a/_includes/multisitenav.html
+++ b/_includes/multisitenav.html
@@ -5,8 +5,7 @@
         CybOX <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li><a href="http://cybox.mitre.org">Main Website</a></li>
-        <li><a href="http://cyboxproject.github.io">Documentation</a></li>
+        <li><a href="https://oasis-open.github.io/cti-documentation/">OASIS CTI Documentation</a></li>
         <li><a href="https://github.com/CybOXProject/">CybOXProject on GitHub</a></li>
       </ul>
     </div>
@@ -15,8 +14,7 @@
         MAEC <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li><a href="http://maec.mitre.org">Main Website</a></li>
-        <li><a href="http://maecproject.github.io">Documentation</a></li>
+        <li><a href="http://maecproject.github.io">Main Website</a></li>
         <li><a href="https://github.com/MAECProject/">MAECProject on GitHub</a></li>
       </ul>
     </div>
@@ -25,8 +23,7 @@
         STIX <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li><a href="http://stix.mitre.org">Main Website</a></li>
-        <li><a href="http://stixproject.github.io">Documentation</a></li>
+        <li><a href="https://oasis-open.github.io/cti-documentation/">OASIS CTI Documentation</a></li>
         <li><a href="https://github.com/STIXProject/">STIXProject on GitHub</a></li>
       </ul>
     </div>
@@ -35,8 +32,7 @@
         TAXII <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
-        <li><a href="http://taxii.mitre.org">Main Website</a></li>
-        <li><a href="http://taxiiproject.github.io">Documentation</a></li>
+        <li><a href="https://oasis-open.github.io/cti-documentation/">OASIS CTI Documentation</a></li>
         <li><a href="https://github.com/TAXIIProject/">TAXIIProject on GitHub</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Updated Documentation links in top nav banner for STIX/TAXII/CybOX to point to CTI Documentation site. Also, fixed main site url for MAEC.