### PR TITLE
Update main site nav in advance of v5.0 rollout

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,12 +17,8 @@
           <ul class="dropdown-menu" role="menu">
             <li role="presentation"><a href="/getting-started">Getting Started Home</a></li>
             <li role="presentation" class="divider"></li>
-            <li role="presentation" class="dropdown-header">Analysts &amp; Managers</li>
             <li role="presentation"><a href="http://maec.mitre.org/about/docs/MAEC_Overview.pdf" target="_blank">Overview (PDF)</a></li>
-            <li role="presentation" class="disabled"><a href="#" class="coming-soon" data-toggle="tooltip" data-placement="right" title="Coming Soon!">Walkthrough</a></li>
-            <li role="presentation" class="disabled"><a href="#" class="coming-soon" data-toggle="tooltip" data-placement="right" title="Coming Soon!">Modeling Exercise</a></li>
             <li role="presentation" class="divider"></li>
-            <li role="presentation" class="dropdown-header">Developers</li>
             <li role="presentation"><a href="https://github.com/MAECProject/python-maec/wiki/Getting-Started">Getting Started with Python</a></li>
             <li role="presentation"><a href="/getting-started/sample-walkthrough">XML Sample Walkthrough</a></li>
             <li role="presentation"><a href="/getting-started/authoring-tutorial">XML Authoring Tutorial</a></li>
@@ -82,21 +78,25 @@
         </li>
 
 	<li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">About/Community/News<span class="caret"></span></a>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Community<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
-            <li role="presentation"><a href="/about-maec">About MAEC</a></li>
-            <li role="presentation" class="divider"></li>  
             <li role="presentation"><a href="/community">Community Home</a></li>
 	    <li role="presentation"><a href="/community/#discussion-lists--archives">Discussion List &amp; Archives</a></li>
 	    <li role="presentation"><a href="/community/#tool--utility-development">Tool &amp; Utility Development</a></li>
 	    <li role="presentation"><a href="/community/#encyclopedia-of-malware-attributes">Encyclopedia of Malware Attributes</a></li>
             <li role="presentation"><a href="/community/supporters">MAEC Supporters</a></li>
-	    <li role="presentation" class="divider"></li>
-            <li role="presentation"><a href="/news">Latest MAEC News</a></li>
-	    <li role="presentation"><a href="/community/#free-newsletter">Free Newsletter</a></li>
           </ul>
+	<li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">About/News<span class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li role="presentation"><a href="/about-maec">About MAEC</a></li>
+            <li role="presentation" class="divider"></li>  
+            <li role="presentation"><a href="/news">Latest News</a></li>
+	    <li role="presentation"><a href="/community/#free-newsletter">Free Newsletter</a></li>
+          </ul>		
+		
 	<li>
-	  <a href="https://collaborate.mitre.org/ema/index.php/ema:Main_Page">EMA</a>
+	  <a href="https://collaborate.mitre.org/ema/index.php/ema:Main_Page">Encyclopedia of Malware Attributes</a>
 	</li>
 		
       </ul>


### PR DESCRIPTION
Spelled-out EMA and made Community a stand-alone section. Also, deleted the two obsolete "coming soon" menu items.