### PR TITLE
Updated site nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -50,13 +50,6 @@
 	<li>
 	  <a href="/about-maec">About MAEC</a>
 	</li>        
-         
-	<li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">News <span class="caret"></span></a>
-          <ul class="dropdown-menu" role="menu">
-            <li role="presentation"><a href="/news">Latest News</a></li>
-	    <li role="presentation"><a href="/community/#free-newsletter">Free Newsletter</a></li>
-          </ul>	    
 	      
 	<li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Community <span class="caret"></span></a>
@@ -66,10 +59,13 @@
 	    <li role="presentation"><a href="/community/#tool--utility-development">Tool &amp; Utility Development</a></li>
 	    <li role="presentation"><a href="/community/#encyclopedia-of-malware-attributes">Encyclopedia of Malware Attributes</a></li>
             <li role="presentation"><a href="/community/supporters">MAEC Supporters</a></li>
+	    <li role="presentation" class="divider"></li>
+            <li role="presentation"><a href="/news">Latest MAEC News</a></li>
+	    <li role="presentation"><a href="/community/#free-newsletter">Free Newsletter</a></li>		  
           </ul>				
 		
 	<li>
-	  <a href="https://collaborate.mitre.org/ema/index.php/ema:Main_Page">Encycl. of Malware Attributes</a>
+	  <a href="https://collaborate.mitre.org/ema/index.php/ema:Main_Page">Encyclopedia of Malware Attributes</a>
 	</li>
 
 	<li>


### PR DESCRIPTION
Moved "News" under "Community" to remove abbreviation from "Encycl. of Malware Attributes" menu item, for a more polished look.